### PR TITLE
Fix install.sh -w short description

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Follow the prompts
 
 The script supports the following flags
 - `-c` Left hand side tab close button
-- `-w` Left hand side window close button
+- `-w` Right hand side window close button
 - `-p` Makes tabs height compact like current Safari
 - `-f` To specify the default firefox folder (it will try to find the profile folder to place the theme within)
 - `-l` Default location of most Linux installations


### PR DESCRIPTION
The readme said `-w` stands for left-hand window close button, but that is the default value (on mac). What `-w` actually does is swap it to the right.