### PR TITLE
Url Bar fixed & Update headerbar.css

### DIFF
--- a/chrome/WhiteSur/parts/headerbar.css
+++ b/chrome/WhiteSur/parts/headerbar.css
@@ -109,6 +109,16 @@ toolbar .toolbarbutton-1{
 	padding: 0 6px !important;
 }
 
+#urlbar[breakout] {
+	position: static !important; 
+}
+
+/* New tab url bar focusing */
+#urlbar[focused]:not([suppress-focus-border]) > #urlbar-background, 
+#searchbar:focus-within {
+	outline: none !important;
+}
+
 #nav-bar #searchbar:focus-within,
 #urlbar[focused] .urlbar-input-container {
 	border: none !important;


### PR DESCRIPTION
In the file .../parts/headerbar.css, I added the position: static property to the #urlbar[breakout] selector. This change was necessary because Firefox was automatically assigning the absolute value, which caused the URL bar to shrink or expand when clicked. By using the static property, this behavior has been prevented.

Removed the outline effect on the URL bar that appeared when opening a new tab, which caused a noticeable focus effect on both sides. Setting the outline to none has resulted in a cleaner, more subtle appearance when opening new tabs.