### PR TITLE
Update lib-install.sh

### DIFF
--- a/lib-install.sh
+++ b/lib-install.sh
@@ -81,6 +81,7 @@ fi
     echo "user_pref(\"browser.tabs.drawInTitlebar\", true);" >>                         "${d}/prefs.js"
     echo "user_pref(\"browser.uidensity\", 0);" >>                                      "${d}/prefs.js"
     echo "user_pref(\"layers.acceleration.force-enabled\", true);" >>                   "${d}/prefs.js"
+    echo "user_pref(\"security.insecure_connection_text.enabled\", false);" >>          "${d}/prefs.js"
     echo "user_pref(\"mozilla.widget.use-argb-visuals\", true);" >>                     "${d}/prefs.js"
   done
 }


### PR DESCRIPTION
After updating to version 136, the message "not protected" appears, remove the message and leave only the icon