### PR TITLE
Remove space between pinned tabs and normal tabs to fix a color inconsistency

### DIFF
--- a/chrome/WhiteSur/parts/tabsbar.css
+++ b/chrome/WhiteSur/parts/tabsbar.css
@@ -470,3 +470,9 @@ transition: all 150ms ease-in !important;
   &[pinned], #tabbrowser-tabs[closebuttons="activetab"][orient="horizontal"] &:not([selected]) {
 display: flex !important;
 	}}
+
+/* Fix background color inconsistency caused by spacing
+ * between pinned tabs and normal tabs */
+#pinned-tabs-container[orient="horizontal"] {
+	margin-inline-end: 0px !important;
+}


### PR DESCRIPTION
There's a CSS rule in Firefox's `tabs.css` which causes a space between pinned tabs and normal tabs:

```css
#pinned-tabs-container[orient="horizontal"] {
	margin-inline-end: 12px;
}
```

I don't really care about that space in itself, but it caused an annoying color inconsistency because the space has a different color than the tabs (though only in dark mode for some reason, and I don't think it was an issue before Firefox 141).

Here's a screenshot of the issue I'm talking about:

<img width="383" height="166" alt="Screenshot 2025-08-01 at 21 24 36" src="https://github.com/user-attachments/assets/4da458a9-9373-4fe1-81d5-f0b06540ee7b" />

Here's a screenshot of how it looks with this change:

<img width="450" height="188" alt="Screenshot 2025-08-01 at 21 38 10" src="https://github.com/user-attachments/assets/e28d0f77-bc38-47b5-9f65-a489e526d29c" />

Maybe the most proper solution would've been to fix the background color issue, but I couldn't figure out how to do that.