### PR TITLE
Fix extension icon not showing

### DIFF
--- a/chrome/WhiteSur/parts/icons.css
+++ b/chrome/WhiteSur/parts/icons.css
@@ -457,7 +457,7 @@ menuitem[type="radio"]:not([disabled="true"]):hover .menu-iconic-icon {
 	}
 
 	/* Fix for extensions icons */
-	.webextension-browser-action {
+	.webextension-browser-action .toolbaricon-icon {
 		list-style-image: var(--webextension-menupanel-image-light, inherit) !important;
 	}
 }

--- a/chrome/WhiteSur/parts/icons.css
+++ b/chrome/WhiteSur/parts/icons.css
@@ -457,7 +457,7 @@ menuitem[type="radio"]:not([disabled="true"]):hover .menu-iconic-icon {
 	}
 
 	/* Fix for extensions icons */
-	.webextension-browser-action .toolbarbutton-icon {
+	.webextension-browser-action {
 		list-style-image: var(--webextension-menupanel-image-light, inherit) !important;
 	}
 }

--- a/chrome/WhiteSur/parts/icons.css
+++ b/chrome/WhiteSur/parts/icons.css
@@ -457,7 +457,7 @@ menuitem[type="radio"]:not([disabled="true"]):hover .menu-iconic-icon {
 	}
 
 	/* Fix for extensions icons */
-	.webextension-browser-action {
+	.webextension-browser-action .toolbarbutton-icon {
 		list-style-image: var(--webextension-menupanel-image-light, inherit) !important;
 	}
 }


### PR DESCRIPTION
There was an issue where some web extension icons did not appear in the header bar.

For example, Ublock Origin icon was not showing, even while the extension was in use.
<img width="196" height="58" alt="fix extension icon 1" src="https://github.com/user-attachments/assets/c695ddc4-423b-4b66-8790-a026e64b14d8" />

With this change, these web extension icons are able to appear.
<img width="192" height="57" alt="fix extension icon 2" src="https://github.com/user-attachments/assets/81b57809-9118-4465-ba61-4bb893d474d8" />

fixes #172 